### PR TITLE
Update apigateway-export-tool dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -913,9 +913,9 @@
       }
     },
     "apigateway-export-tool": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/apigateway-export-tool/-/apigateway-export-tool-0.0.12.tgz",
-      "integrity": "sha512-s6C/GleKq25QqGxtNj+JEjZlRPLmBmcTN6wYvf6RbZYhXkywvcyZPshIvYmHCUaenQqIpGPvF3RFVwb98+G0jQ==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/apigateway-export-tool/-/apigateway-export-tool-0.0.13.tgz",
+      "integrity": "sha512-ZgHJa41wMG1aTC4RQRnpPeFYOERvo0Tg9WP+8A8wkcNBNqx9Ew8JsEIULA2K0xMb5zp896mY13HeA1BSAMsLyw==",
       "requires": {
         "aws-sdk": "^2.441.0",
         "commander": "^2.20.0",
@@ -970,9 +970,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.444.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.444.0.tgz",
-      "integrity": "sha512-3vdC7l5BJ3zHzVNgtIxD+TDviti/sAA/1T8zAXAm2XhZ7AePR5lYIMNAwqu+J44Nm6PFSK1QNSzRQ6A4/6b9eA==",
+      "version": "2.463.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.463.0.tgz",
+      "integrity": "sha512-bl0S6mxA2o8Hpy9LsMcPC9kVnrL4+B4qayiMlNMrp+8gcEMzJSMzfrUDX4SCWsqGYT25sZn8TDqTGJp7XIh3yw==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -1912,8 +1912,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1934,14 +1933,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1956,20 +1953,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2086,8 +2080,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2099,7 +2092,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2114,7 +2106,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2122,14 +2113,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2148,7 +2137,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2229,8 +2217,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2242,7 +2229,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2328,8 +2314,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2365,7 +2350,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2385,7 +2369,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2429,14 +2412,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4092,11 +4073,6 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
-    },
-    "swagger-editor-dist": {
-      "version": "3.6.28",
-      "resolved": "https://registry.npmjs.org/swagger-editor-dist/-/swagger-editor-dist-3.6.28.tgz",
-      "integrity": "sha512-xVqL4ON6Ygw7ceNTplTITVcuociemqBg7ZcNXa02BrGY/yf5cH7lRSNecFUpK1ZBhJ04GzFhEGEvXty9eZnhlw=="
     },
     "term-size": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "ISC",
   "dependencies": {
     "@babel/polyfill": "^7.4.4",
-    "apigateway-export-tool": "0.0.12",
+    "apigateway-export-tool": "^0.0.13",
     "commander": "^2.20.0",
     "configstore": "^4.0.0",
     "cookie-parser": "^1.4.4",


### PR DESCRIPTION
Updates the API Gateway exporter tool to 0.0.13 so that the region can be specified during runtime:

```shell
> AWS_DEFAULT_REGION=eu-west-1 npm start
```
